### PR TITLE
Fix get config netconf operation

### DIFF
--- a/netconf/message/get.go
+++ b/netconf/message/get.go
@@ -20,8 +20,9 @@ package message
 // https://datatracker.ietf.org/doc/html/rfc6241#section-7.7
 type Get struct {
 	RPC
-	Get    interface{} `xml:"get"`
-	Filter *Filter
+	Get struct {
+		Filter *Filter `xml:"filter"`
+	} `xml:"get"`
 }
 
 // NewGet can be used to create a `get` message.
@@ -35,9 +36,7 @@ func NewGet(filterType string, data string) *Get {
 			Type: filterType,
 			Data: data,
 		}
-		rpc.Filter = &filter
-	} else {
-		rpc.Get = ""
+		rpc.Get.Filter = &filter
 	}
 	rpc.MessageID = uuid()
 	return &rpc


### PR DESCRIPTION
This PR,
Fixes: https://github.com/openshift-telco/go-netconf-client/issues/1

Before this change,
Following was the get request created:
```
<?xml version="1.0" encoding="UTF-8"?>
<rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="761849ec-9a3c-440b-98bf-92b3bcaedc7d"><filter type="subtree"><data></data></filter></rpc>]]>]]>
```

After this change,
Following is the get request created:
```
<?xml version="1.0" encoding="UTF-8"?>
<rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="aa251dd8-2d60-4385-b888-1eff1a68a00c"><get><filter type="subtree"><data></data></filter></get></rpc>]]>]]>
```