### PR TITLE
Add support for NETCONF copy-config operation.

### DIFF
--- a/netconf/message/common.go
+++ b/netconf/message/common.go
@@ -26,6 +26,8 @@ import (
 const (
 	// FilterTypeSubtree represent the filter for get operation
 	FilterTypeSubtree string = "subtree"
+	// DatastoreStartup represents the startup datastore
+	DatastoreStartup string = "startup"
 	// DatastoreRunning represents the running datastore
 	DatastoreRunning string = "running"
 	// DatastoreCandidate represents the candidate datastore
@@ -49,12 +51,15 @@ type Filter struct {
 type Datastore struct {
 	Candidate interface{} `xml:"candidate,omitempty"`
 	Running   interface{} `xml:"running,omitempty"`
+	Startup   interface{} `xml:"startup,omitempty"`
 }
 
 // datastore returns a Datastore object populated with appropriate datastoreType
 func datastore(datastoreType string) *Datastore {
 	validateDatastore(datastoreType)
 	switch datastoreType {
+	case DatastoreStartup:
+		return &Datastore{Startup: ""}
 	case DatastoreRunning:
 		return &Datastore{Running: ""}
 	case DatastoreCandidate:
@@ -83,6 +88,8 @@ func ValidateXML(data string, dataStruct interface{}) {
 // validateDatastore checks the provided string is a supported Datastore
 func validateDatastore(datastore string) {
 	switch datastore {
+	case DatastoreStartup:
+		return
 	case DatastoreRunning:
 		return
 	case DatastoreCandidate:

--- a/netconf/message/copy-config.go
+++ b/netconf/message/copy-config.go
@@ -1,0 +1,18 @@
+package message
+
+// CopyConfig represents the NETCONF `copy-config` operation.
+// https://datatracker.ietf.org/doc/html/rfc6241#section-7.3
+type CopyConfig struct {
+	RPC
+	Target *Datastore `xml:"copy-config>target"`
+	Source *Datastore `xml:"copy-config>source"`
+}
+
+// NewCopyConfig can be used to create a `copy-config` message.
+func NewCopyConfig(target string, source string) *CopyConfig {
+	var rpc CopyConfig
+	rpc.Target = datastore(target)
+	rpc.Source = datastore(source)
+	rpc.MessageID = uuid()
+	return &rpc
+}


### PR DESCRIPTION
Add support for NETCONF copy-config operation. Add support for startup datastore.
In my use case, I need to update the startup datastore after any edit config to the running datastore. This allows the change to persist in case the device restarts.