### PR TITLE
Fixing error handling when establishing session

### DIFF
--- a/netconf/session.go
+++ b/netconf/session.go
@@ -49,7 +49,7 @@ type Session struct {
 }
 
 // NewSession creates a new NETCONF session using the provided transport layer.
-func NewSession(t Transport, options ...SessionOption) *Session {
+func NewSession(t Transport, options ...SessionOption) (*Session, error) {
 	s := new(Session)
 	for _, opt := range options {
 		opt(s)
@@ -62,14 +62,17 @@ func NewSession(t Transport, options ...SessionOption) *Session {
 	s.Transport = t
 
 	// Receive server Hello message
-	serverHello, _ := s.ReceiveHello()
+	serverHello, err := s.ReceiveHello()
+	if err != nil {
+		return nil, err
+	}
 	s.SessionID = serverHello.SessionID
 	s.Capabilities = serverHello.Capabilities
 
 	s.Listener = &Dispatcher{}
 	s.Listener.init()
 
-	return s
+	return s, nil
 }
 
 // WithSessionLogger set the session logger provided in the session option.

--- a/netconf/sessionfactory.go
+++ b/netconf/sessionfactory.go
@@ -15,7 +15,10 @@ func NewSessionFromSSHConfig(target string, config *ssh.ClientConfig, options ..
 		return nil, fmt.Errorf("DialSSHTimeout: %w", err)
 	}
 
-	s := NewSession(t, options...)
+	s, err := NewSession(t, options...)
+	if err != nil {
+		return nil, err
+	}
 
 	return s, nil
 }
@@ -27,7 +30,10 @@ func NewSessionFromSSHConfigTimeout(ctx context.Context, target string, config *
 		return nil, fmt.Errorf("DialSSHTimeout: %w", err)
 	}
 
-	s := NewSession(t, options...)
+	s, err := NewSession(t, options...)
+	if err != nil {
+		return nil, err
+	}
 
 	return s, nil
 }
@@ -39,7 +45,10 @@ func NewSessionFromSSHClient(ctx context.Context, client *ssh.Client, options ..
 		return nil, fmt.Errorf("NoDialSSH: %w", err)
 	}
 
-	s := NewSession(t, options...)
+	s, err := NewSession(t, options...)
+	if err != nil {
+		return nil, err
+	}
 
 	return s, nil
 }


### PR DESCRIPTION
This PR brings back abandoned error handling, when establishing SSH session.
With current implementation, when SSH handshake fails, it leads to `nil pointer dereference` what crashes Golang program (or microservice).

Any input or possible improvements of that PR are very welcome!