### PR TITLE
Added filtering functionality to subscription creation

### DIFF
--- a/netconf/message/notification.go
+++ b/netconf/message/notification.go
@@ -91,18 +91,7 @@ func NewCreateSubscriptionDefault() *CreateSubscription {
 }
 
 // NewCreateSubscription can be used to create a `create-subscription` message.
-func NewCreateSubscription(stopTime string, startTime string, stream string) *CreateSubscription {
-	var rpc CreateSubscription
-	var sub = &CreateSubscriptionData{
-		NetconfNotificationXmlns, stream, "", startTime, stopTime,
-	}
-	rpc.Subscription = *sub
-	rpc.MessageID = uuid()
-	return &rpc
-}
-
-// NewCreateSubscriptionFiltered can be used to create a `create-subscription` message with a filter parameter
-func NewCreateSubscriptionFiltered(stopTime string, startTime string, stream string, filter string) *CreateSubscription {
+func NewCreateSubscription(stopTime string, startTime string, stream string, filter string) *CreateSubscription {
 	var rpc CreateSubscription
 	var sub = &CreateSubscriptionData{
 		NetconfNotificationXmlns, stream, filter, startTime, stopTime,

--- a/netconf/message/notification.go
+++ b/netconf/message/notification.go
@@ -74,6 +74,7 @@ type CreateSubscription struct {
 type CreateSubscriptionData struct {
 	XMLNS     string `xml:"xmlns,attr"`
 	Stream    string `xml:"stream,omitempty"` // default is NETCONF
+	Filter    string `xml:",innerxml"`
 	StartTime string `xml:"startTime,omitempty"`
 	StopTime  string `xml:"stopTime,omitempty"`
 }
@@ -82,7 +83,7 @@ type CreateSubscriptionData struct {
 func NewCreateSubscriptionDefault() *CreateSubscription {
 	var rpc CreateSubscription
 	var sub = &CreateSubscriptionData{
-		NetconfNotificationXmlns, "", "", "",
+		NetconfNotificationXmlns, "", "", "", "",
 	}
 	rpc.Subscription = *sub
 	rpc.MessageID = uuid()
@@ -93,7 +94,18 @@ func NewCreateSubscriptionDefault() *CreateSubscription {
 func NewCreateSubscription(stopTime string, startTime string, stream string) *CreateSubscription {
 	var rpc CreateSubscription
 	var sub = &CreateSubscriptionData{
-		NetconfNotificationXmlns, stream, startTime, stopTime,
+		NetconfNotificationXmlns, stream, "", startTime, stopTime,
+	}
+	rpc.Subscription = *sub
+	rpc.MessageID = uuid()
+	return &rpc
+}
+
+// NewCreateSubscriptionFiltered can be used to create a `create-subscription` message with a filter parameter
+func NewCreateSubscriptionFiltered(stopTime string, startTime string, stream string, filter string) *CreateSubscription {
+	var rpc CreateSubscription
+	var sub = &CreateSubscriptionData{
+		NetconfNotificationXmlns, stream, filter, startTime, stopTime,
 	}
 	rpc.Subscription = *sub
 	rpc.MessageID = uuid()

--- a/netconf/operations.go
+++ b/netconf/operations.go
@@ -29,29 +29,6 @@ import (
 // TODO limitation - for now, we can only register one stream per session, because when a notification is received
 // there is no way to attribute it to a specific stream
 func (session *Session) CreateNotificationStream(
-	timeout int32, stopTime string, startTime string, stream string, callback Callback,
-) error {
-	if session.IsNotificationStreamCreated {
-		return fmt.Errorf(
-			"there is already an active notification stream subscription. " +
-				"A session can only support one notification stream at the time",
-		)
-	}
-	session.Listener.Register(message.NetconfNotificationStreamHandler, callback)
-	sub := message.NewCreateSubscription(stopTime, startTime, stream)
-	rpc, err := session.SyncRPC(sub, timeout)
-	if err != nil {
-		errMsg := "fail to create notification stream"
-		if rpc != nil && len(rpc.Errors) != 0 {
-			errMsg += fmt.Sprintf(" with errors: %s", rpc.Errors)
-		}
-		return fmt.Errorf("%s: %w", errMsg, err)
-	}
-	session.IsNotificationStreamCreated = true
-	return nil
-}
-
-func (session *Session) CreateNotificationStreamFiltered(
 	timeout int32, stopTime string, startTime string, filter string, stream string, callback Callback,
 ) error {
 	if session.IsNotificationStreamCreated {
@@ -61,7 +38,7 @@ func (session *Session) CreateNotificationStreamFiltered(
 		)
 	}
 	session.Listener.Register(message.NetconfNotificationStreamHandler, callback)
-	sub := message.NewCreateSubscriptionFiltered(stopTime, startTime, stream, filter)
+	sub := message.NewCreateSubscription(stopTime, startTime, stream, filter)
 	rpc, err := session.SyncRPC(sub, timeout)
 	if err != nil {
 		errMsg := "fail to create notification stream"


### PR DESCRIPTION
Added:
CreateNotificationStreamFiltered()
NewCreateSubscriptionFiltered()
Filter field to struct CreateSubscriptionData

Filters are passed in as a string to the CreateNotificationStreamFiltered function.
The string should have no newlines and be in XML format, containing the filter tag and all desired components inside of it.
Ex. `filter := "<filter><severity>critical</severity></filter>"`
Filtering otherwise follows standard [NETCONF rules](https://datatracker.ietf.org/doc/html/rfc6241#section-6)

Addresses issue #13 